### PR TITLE
Updating the scripts to support newer versions of Tensorflow, Bazel and cuDNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This script is for the following specific versions:
 
 | Name       | Version |
 |------------|---------|
-| TensorFlow | 0.6.0   |
+| TensorFlow | 0.9.0   |
 | CUDA       | 7.0     |
-| cuDNN      | 6.5     |
+| cuDNN      | 7.0     |
 | Java       | 8       |
-| Bazel      | 0.1.4   |
+| Bazel      | 0.2.3   |
 | Python     | 2.7.6   |
 
 ## Usage

--- a/toa_part_1of2.sh
+++ b/toa_part_1of2.sh
@@ -55,10 +55,10 @@ sudo apt-get install -y oracle-java8-installer
 
 # Install Bazel
 sudo apt-get install pkg-config zip g++ zlib1g-dev unzip
-wget https://github.com/bazelbuild/bazel/releases/download/0.1.4/bazel-0.1.4-installer-linux-x86_64.sh
-chmod +x bazel-0.1.4-installer-linux-x86_64.sh
-./bazel-0.1.4-installer-linux-x86_64.sh --user
-rm bazel-0.1.4-installer-linux-x86_64.sh
+wget https://github.com/bazelbuild/bazel/releases/download/0.2.3/bazel-0.2.3-installer-linux-x86_64.sh
+chmod +x bazel-0.2.3-installer-linux-x86_64.sh
+./bazel-0.2.3-installer-linux-x86_64.sh --user
+rm bazel-0.2.3-installer-linux-x86_64.sh
 
 # Clone tensorflow repo
 git clone --recurse-submodules https://github.com/tensorflow/tensorflow

--- a/toa_part_1of2.sh
+++ b/toa_part_1of2.sh
@@ -33,8 +33,7 @@ sudo apt-get install -y cuda
 
 # Install cuDNN
 wget $CUDNN_URL
-tar -xf cudnn-6.5-linux-x64-v2.tar
-rm cudnn-6.5-linux-x64-v2.tar
+tar -zxf cudnn-6.5-linux-x64-v2.tgz && rm cudnn-6.5-linux-x64-v2.tgz
 sudo cp -R cudnn-6.5-linux-x64-v2/lib* /usr/local/cuda/lib64/
 sudo cp cudnn-6.5-linux-x64-v2/cudnn.h /usr/local/cuda/include/
 

--- a/toa_part_1of2.sh
+++ b/toa_part_1of2.sh
@@ -7,7 +7,7 @@ echo "Running installer part 1 of 2"
 # This script requires an Nvidia Accelerated Computing Developer Program account
 # Register for an account at: https://developer.nvidia.com
 # Once accepted (typically takes about a day), download cuDNN from:
-# https://developer.nvidia.com/rdp/assets/cudnn-65-linux-v2-asset
+# https://developer.nvidia.com/rdp/assets/cudnn-70-linux-x64-v40
 # Host this file on a private location and point to it using CUDNN_URL
 CUDNN_URL=
 
@@ -33,9 +33,9 @@ sudo apt-get install -y cuda
 
 # Install cuDNN
 wget $CUDNN_URL
-tar -zxf cudnn-6.5-linux-x64-v2.tgz && rm cudnn-6.5-linux-x64-v2.tgz
-sudo cp -R cudnn-6.5-linux-x64-v2/lib* /usr/local/cuda/lib64/
-sudo cp cudnn-6.5-linux-x64-v2/cudnn.h /usr/local/cuda/include/
+tar -zxf cudnn-7.0-linux-x64-v4.0-prod.tgz && rm cudnn-7.0-linux-x64-v4.0-prod.tgz
+sudo cp cuda/lib64/* /usr/local/cuda/lib64/
+sudo cp cuda/include/cudnn.h /usr/local/cuda/include/
 
 # Add environmental variables
 echo >> .bashrc


### PR DESCRIPTION
I have encountered some errors using these scripts on a fresh install of ubuntu 14.04 on an AWS EC2 `g2.2xlarge` server. The things that were changed are as following:
- Updating `basel` to `0.2.3` in order to resolve:
  `ERROR: /mnt/tmp/tensorflow/tensorflow/core/BUILD:87:1: //tensorflow/core:protos_all_py: no such attribute 'imports' in 'py_library' rule.`
  More information can be found [here](https://github.com/tensorflow/tensorflow/issues/1452).
- Updating `cuDNN` to `v4` in order to resolve unknown symbols, according to [here](https://github.com/tensorflow/tensorflow/issues/3074).
- `cuDNN v4` has a different directory structure. I updated the script to reflect that.
